### PR TITLE
Add config option for ignored branch pushes

### DIFF
--- a/Matterhook.NET/Config.cs
+++ b/Matterhook.NET/Config.cs
@@ -54,6 +54,7 @@ namespace Matterhook.NET
         public MattermostConfig DefaultMattermostConfig { get; set; }
         public List<RepoConfig> RepoList { get; set; }
         public bool DebugSavePayloads { get; set; } = false;
+        public string[] IgnoredBranchPushes { get; set; }
     }
 
     public class RepoConfig

--- a/Matterhook.NET/Controllers/GitHubHookController.cs
+++ b/Matterhook.NET/Controllers/GitHubHookController.cs
@@ -257,9 +257,16 @@ namespace Matterhook.NET.Controllers
 
                     if (payload.commits.Count > 0)
                     {
+                        var branch = payload._ref.Replace("refs/heads/", "");
+
+                        // Check if this branch is ignored
+                        if(_config.IgnoredBranchPushes.Contains(branch))
+                        {
+                            throw new WarningException("Branch of pushed commit matches an ignored branch");
+                        }
+
                         var multi = payload.commits.Count > 1 ? "s" : "";
                         var userMd = $"[{payload.sender.login}]({payload.sender.html_url})";
-                        var branch = payload._ref.Replace("refs/heads/", "");
                         var branchMd = $"[{branch}]({payload.repository.html_url}/tree/{branch})";
                         var repoMd = $"[{payload.repository.full_name}]({payload.repository.html_url})";
                         retVal.Text =


### PR DESCRIPTION
The `IgnoredBranchPushes` config option in the GitHub config is a list of branches. Pushes to these branches are ignored.