### PR TITLE
Add config option for ignored branch pushes

### DIFF
--- a/Matterhook.NET/Config.cs
+++ b/Matterhook.NET/Config.cs
@@ -54,6 +54,7 @@ namespace Matterhook.NET
         public MattermostConfig DefaultMattermostConfig { get; set; }
         public List<RepoConfig> RepoList { get; set; }
         public bool DebugSavePayloads { get; set; } = false;
+        public string[] IgnoredBranchPushes { get; set; }
     }
 
     public class RepoConfig

--- a/Matterhook.NET/Config.cs
+++ b/Matterhook.NET/Config.cs
@@ -54,7 +54,6 @@ namespace Matterhook.NET
         public MattermostConfig DefaultMattermostConfig { get; set; }
         public List<RepoConfig> RepoList { get; set; }
         public bool DebugSavePayloads { get; set; } = false;
-        public string[] IgnoredBranchPushes { get; set; }
     }
 
     public class RepoConfig
@@ -67,6 +66,7 @@ namespace Matterhook.NET
     public class Filters
     {
         public StatusFilter Status { get; set; } = new StatusFilter();
+        public string[] IgnoredBranchPushes { get; set; }
     }
 
     public class Filter

--- a/Matterhook.NET/Controllers/GitHubHookController.cs
+++ b/Matterhook.NET/Controllers/GitHubHookController.cs
@@ -257,9 +257,16 @@ namespace Matterhook.NET.Controllers
 
                     if (payload.commits.Count > 0)
                     {
+                        var branch = payload._ref.Replace("refs/heads/", "");
+
+                        // Check if this branch is ignored
+                        if(_config.IgnoredBranchPushes.Contains(branch))
+                        {
+                            throw new WarningException("Branch of pushed commit matches an ignored branch");
+                        }
+
                         var multi = payload.commits.Count > 1 ? "s" : "";
                         var userMd = $"[{payload.sender.login}]({payload.sender.html_url})";
-                        var branch = payload._ref.Replace("refs/heads/", "");
                         var branchMd = $"[{branch}]({payload.repository.html_url}/tree/{branch})";
                         var repoMd = $"[{payload.repository.full_name}]({payload.repository.html_url})";
                         retVal.Text =

--- a/Matterhook.NET/Controllers/GitHubHookController.cs
+++ b/Matterhook.NET/Controllers/GitHubHookController.cs
@@ -29,7 +29,7 @@ namespace Matterhook.NET.Controllers
             try
             {
                 _config = config.Value.GithubConfig;
-                
+
             }
             catch (ArgumentException e)
             {
@@ -257,10 +257,11 @@ namespace Matterhook.NET.Controllers
 
                     if (payload.commits.Count > 0)
                     {
+                        var filters = GetRepoFilters(payload.repository.full_name);
                         var branch = payload._ref.Replace("refs/heads/", "");
 
                         // Check if this branch is ignored
-                        if(_config.IgnoredBranchPushes.Contains(branch))
+                        if(filters.IgnoredBranchPushes.Contains(branch))
                         {
                             throw new WarningException("Branch of pushed commit matches an ignored branch");
                         }


### PR DESCRIPTION
The `IgnoredBranchPushes` config option in the GitHub config is a list
of branches. Pushes to these branches are ignored.

Signed-off-by: Mcat12 <newtoncat12@yahoo.com>